### PR TITLE
Some small code changes to make MHCnuggets python3 compatible

### DIFF
--- a/mhcnuggets/src/find_closest_mhcI.py
+++ b/mhcnuggets/src/find_closest_mhcI.py
@@ -5,7 +5,10 @@ one is based on training data
 """
 
 from mhcnuggets.src.dataset import Dataset
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import operator
 import os
 MHCNUGGETS_HOME = os.path.join(os.path.dirname(__file__), '..')

--- a/mhcnuggets/src/find_closest_mhcI.py
+++ b/mhcnuggets/src/find_closest_mhcI.py
@@ -52,7 +52,7 @@ def closest_allele(mhc):
         _sub_type = int(mhc[7:9])
 
     except ValueError as e:
-        print "Invalid human allele"
+        print("Invalid human allele")
         return
 
     # find if there's a supertype, and select
@@ -106,7 +106,7 @@ def main():
                             key=operator.itemgetter(1))
 
     for a in sorted_alleles:
-        print a
+        print(a)
     pickle.dump(allele_example_dict, open("data/production/examples_per_allele.pkl", 'wb'))
 
 

--- a/mhcnuggets/src/find_closest_mhcII.py
+++ b/mhcnuggets/src/find_closest_mhcII.py
@@ -52,7 +52,7 @@ def closest_allele(mhc):
         _sub_type = int(mhc[10:12])
 
     except ValueError as e:
-        print "Invalid human allele"
+        print("Invalid human allele")
         return
 
     # find if there's a supertype, and select
@@ -102,7 +102,7 @@ def main():
     sorted_alleles = sorted(allele_example_dict.items(),
                             key=operator.itemgetter(1))
     for a in sorted_alleles:
-        print a
+        print(a)
     pickle.dump(allele_example_dict, open("data/production/examples_per_allele.pkl", 'wb'))
 
 if __name__ == "__main__":

--- a/mhcnuggets/src/find_closest_mhcII.py
+++ b/mhcnuggets/src/find_closest_mhcII.py
@@ -5,7 +5,10 @@ one is based on training data
 """
 
 from mhcnuggets.src.dataset import Dataset
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import operator
 import os
 MHCNUGGETS_HOME = os.path.join(os.path.dirname(__file__), '..')


### PR DESCRIPTION
This fixes a few `print` statements that were missing their braces. The biggest change is to the pickle import to use the `pickle` module as a fallback when cPickle is not available since cPickle is only available in python2.

I successfully ran the predict commands from a python3 environment with these changes.