### PR TITLE
Closed prediction results file and redirected comments to stderr.

### DIFF
--- a/mhcnuggets/src/predict.py
+++ b/mhcnuggets/src/predict.py
@@ -86,9 +86,13 @@ def predict(class_, peptides_path, mhc, pickle_path='data/production/examples_pe
     else:
         filehandle = sys.stdout
 
-    print(','.join(('peptide', 'ic50')), file=filehandle)
-    for i, peptide in enumerate(original_peptides):
-        print(','.join((peptide, str(round(ic50s[i],2)))), file=filehandle)
+    try:
+        print(','.join(('peptide', 'ic50')), file=filehandle)
+        for i, peptide in enumerate(original_peptides):
+            print(','.join((peptide, str(round(ic50s[i],2)))), file=filehandle)
+    finally:
+        if output:
+            filehandle.close()
 
 
 


### PR DESCRIPTION
Hi,

we use MHCnuggets for the Fred2 framework, where the `predict` function is imported and called multiple times. I realised that in some cases the output file is still empty when accessed again, because the `filehandle` was not closed. To address this I added a closing at the end of the function. Also, more as a suggestion, I redirected the logging information to stderr to avoid them ending up in the same file as the actual prediction results when using stdout for the output. 