### PR TITLE
Add stub of continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: python
+
+script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: python
 
-script: pytest
+script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: python
 
-script: make test
+# There are no tests yet
+script: make test || true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MHCnuggets
 
+[![Build Status](https://travis-ci.org/richelbilderbeek/mhcnuggets.svg?branch=master)](https://travis-ci.org/richelbilderbeek/mhcnuggets)
+
 Welcome to MHCnuggets! Presumably you're here to do some
 peptide-MHC prediction and not because you were [hungry](https://www.mcdonalds.com/us/en-us/product/chicken-mcnuggets-4-piece.html).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MHCnuggets
 
-[![Build Status](https://travis-ci.org/richelbilderbeek/mhcnuggets.svg?branch=master)](https://travis-ci.org/richelbilderbeek/mhcnuggets)
+[![Build Status](https://travis-ci.org/KarchinLab/mhcnuggets.svg?branch=master)](https://travis-ci.org/KarchinLab/mhcnuggets)
 
 Welcome to MHCnuggets! Presumably you're here to do some
 peptide-MHC prediction and not because you were [hungry](https://www.mcdonalds.com/us/en-us/product/chicken-mcnuggets-4-piece.html).

--- a/mhcnuggets/README.md
+++ b/mhcnuggets/README.md
@@ -14,7 +14,7 @@ MHCnuggets is `pip` installable as:
 pip install mhcnuggets
 ```
 
-**Required pacakges:**
+**Required packages:**
 
 * numpy
 * scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+scipy
+scikit-learn
+pandas
+tensorflow
+keras
+


### PR DESCRIPTION
Hi,

I implemented [this Issue](https://github.com/KarchinLab/mhcnuggets/issues/11) by adding Continuous Integration. It is mustly a stub, however, as there are not tests yet within the package (I will request a new Issue to add these). Still, it's a good first step.

What needs to be done is that Travis CI is activated. Simple: log in in GitHub, click the Travis CI build badge in README, then activate the repo. The badge will update upon the next `git` commit. Here is how it looks:

![Screenshot from 2020-05-25 14-18-21](https://user-images.githubusercontent.com/2098230/82812160-ac383500-9e92-11ea-9bab-f30b314b1737.png)

Thanks for allowing me to help and cheers, Richel Bilderbeek, postdoc