### PR TITLE
Add start of continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: python
+
+script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: python
 
-script: pytest
+script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: python
 
-script: make test
+# There are no tests yet
+script: make test || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
 
 # There are no tests yet
+
 script: make test || true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MHCnuggets
 
+[![Build Status](https://travis-ci.org/richelbilderbeek/mhcnuggets.svg?branch=master)](https://travis-ci.org/richelbilderbeek/mhcnuggets)
+
 Welcome to MHCnuggets! Presumably you're here to do some
 peptide-MHC prediction and not because you were [hungry](https://www.mcdonalds.com/us/en-us/product/chicken-mcnuggets-4-piece.html).
 

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ pip install mhcnuggets
 * keras
 
 You might want to check if the Keras backend is configured to use
-the Tensforflow backend.
+the Tensorflow backend.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MHCnuggets
 
-[![Build Status](https://travis-ci.org/richelbilderbeek/mhcnuggets.svg?branch=master)](https://travis-ci.org/richelbilderbeek/mhcnuggets)
+[![Build Status](https://travis-ci.org/KarchinLab/mhcnuggets.svg?branch=master)](https://travis-ci.org/KarchinLab/mhcnuggets)
 
 Welcome to MHCnuggets! Presumably you're here to do some
 peptide-MHC prediction and not because you were [hungry](https://www.mcdonalds.com/us/en-us/product/chicken-mcnuggets-4-piece.html).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # MHCnuggets
 
-[![Build Status](https://travis-ci.org/KarchinLab/mhcnuggets.svg?branch=master)](https://travis-ci.org/KarchinLab/mhcnuggets)
+Branch   |[Travis CI build status](https://travis-ci.org)                                                                 
+---------|------------------------------------------------------------------------------------------------------------------------------
+`master` |[![Build Status](https://travis-ci.org/KarchinLab/mhcnuggets.svg?branch=master)](https://travis-ci.org/KarchinLab/mhcnuggets) 
+`develop`|[![Build Status](https://travis-ci.org/KarchinLab/mhcnuggets.svg?branch=develop)](https://travis-ci.org/KarchinLab/mhcnuggets)
+`richel` |[![Build Status](https://travis-ci.org/KarchinLab/mhcnuggets.svg?branch=richel)](https://travis-ci.org/KarchinLab/mhcnuggets)
 
 Welcome to MHCnuggets! Presumably you're here to do some
 peptide-MHC prediction and not because you were [hungry](https://www.mcdonalds.com/us/en-us/product/chicken-mcnuggets-4-piece.html).

--- a/mhcnuggets/README.md
+++ b/mhcnuggets/README.md
@@ -24,4 +24,4 @@ pip install mhcnuggets
 * keras
 
 You might want to check if the Keras backend is configured to use
-the Tensforflow backend.
+the Tensorflow backend.

--- a/mhcnuggets/README.md
+++ b/mhcnuggets/README.md
@@ -14,7 +14,7 @@ MHCnuggets is `pip` installable as:
 pip install mhcnuggets
 ```
 
-**Required pacakges:**
+**Required packages:**
 
 * numpy
 * scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+scipy
+scikit-learn
+pandas
+tensorflow
+keras
+


### PR DESCRIPTION
Hi Melody,

Here I added a stub for the continuous integration. CI is important, as it shows the quality of the project, as well as helps collaborators know when they break the build. There will be future Pull Requests that will build upon this one.

One visible change is in the `README.md`, where I put a build status table. I find these very useful. I use my own style to display these, but I don't care much about the exact layout :+1:

Thanks, Richel