### PR TITLE
Change behaviour of the find_weighted_optimal_allele function. 

### DIFF
--- a/mhcnuggets/src/find_closest_mhcII.py
+++ b/mhcnuggets/src/find_closest_mhcII.py
@@ -97,6 +97,7 @@ def find_weighted_optimal_allele(allele_lists, examples_per_allele_shortened,
     training sample sizes and other specified criteria.
     """
     closest_mhc = ''
+    former_allele = ''
     for allele_list in allele_lists:
         for allele in allele_list:
             if allele in examples_per_allele_shortened and better_allele(allele, former_allele,

--- a/mhcnuggets/src/find_closest_mhcII.py
+++ b/mhcnuggets/src/find_closest_mhcII.py
@@ -99,9 +99,10 @@ def find_weighted_optimal_allele(allele_lists, examples_per_allele_shortened,
     closest_mhc = ''
     for allele_list in allele_lists:
         for allele in allele_list:
-            if allele in examples_per_allele_shortened and better_allele(allele, closest_mhc,
+            if allele in examples_per_allele_shortened and better_allele(allele, former_allele,
                                                                          examples_per_allele_shortened):
                 closest_mhc = short_to_full_alleles[allele]
+                former_allele = allele
         if closest_mhc != "":
             break
     return closest_mhc


### PR DESCRIPTION
Problematic behavior found when trying to query most HLA-DQAxxx-DQB102:01 alleles with predict(class_='II'...) -> KeyError 'HLA-DQA103:01-DQB103:02'. 

Behavior can be replicated on master by trying:
`predict(class_='II', peptides_path='anypep.pep', mhc='HLA-DQA101:01-DQB102:01')`

After tracking source of the problem, it appears that find_weighted_optimal_allele queries the examples_per_allele_shortened dictionary using closest_mhc, which is the full allele name. In most cases this does not trigger an error simply due to the structure of the clades I guess ?
Proposed fix: Now the function stores the former allele in its shortened version as former_allele in the loop and querying happens using examples_per_allele_shortened[former_allele].