### PR TITLE
Improve how rank file name is determined

### DIFF
--- a/mhcnuggets/src/predict.py
+++ b/mhcnuggets/src/predict.py
@@ -119,9 +119,11 @@ def predict(class_, peptides_path, mhc, pickle_path='data/production/examples_pe
         ic50_ranks = get_ranks(ic50s,hp_ic50_pickle,hp_lengths_pickle,
                                first_percentiles_pickle,ic50_pos_pickle,predictor_mhc)
         if (output):
-            if len(output.split('.')) > 1:
-                rank_filehandle = open(''.join(output.split('.')[:-1] + ['_ranks.'] + \
-                                               [output.split('.')[-1]]), 'w')
+            (dir_name, full_file_name) = os.path.split(output)
+            if '.' in full_file_name:
+                (file_name, extension) = os.path.splitext(full_file_name)
+                rank_file_name = os.path.join(dir_name, "{}_ranks.{}".format(file_name, extension))
+                rank_filehandle = open(rank_file_name, 'w')
             else:
                 rank_filehandle = open(output + '_ranks', 'w')
         else:


### PR DESCRIPTION
The current implementation will fail if the `output` contains  a `.` in a directory with error such as this: 
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pvactools/lib/call_mhcnuggets.py", line 82, in <module>
    main()
  File "/usr/local/lib/python3.7/site-packages/pvactools/lib/call_mhcnuggets.py", line 59, in main
    predict(args.class_type, tmp_file.name, mhcnuggets_allele(args.allele, args.class_type), output=tmp_output_file.name, rank_output=True)
  File "/usr/local/lib/python3.7/site-packages/mhcnuggets/src/predict.py", line 124, in predict
    [output.split('.')[-1]]), 'w')
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/629867_ranks.tmpdir/tmpznq28ece'
```

This PR updates how the rank file name is determined to correctly split on file extension only.